### PR TITLE
re-implement pam service portion of startup script and Docker compose file

### DIFF
--- a/dev-scripts/start-service-and-database.sh
+++ b/dev-scripts/start-service-and-database.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# TODO: Reimplement automatically building the Spring Boot application. Coordinate changes with the docker-compose.yml file.
-# Clean and build the Spring Boot application
-# ./mvnw clean install
+# Clean and build the Spring Boot application, but skip Flyway migrations since the database is not yet running
+./mvnw clean install -Pskip-flyway
 
 # Start Docker containers
 sudo docker compose up --build -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,29 +11,28 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    # networks:
-    #   - pam_network
+    networks:
+      - pam_network
 
-# TODO: Reimplement the spring-app service. Coordinate changes with start-service-and-database.sh file.
-  # spring-app:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #   container_name: pam_spring_app
-  #   restart: always
-  #   ports:
-  #     - "8081:8081"
-  #   environment:
-  #     SPRING_DATASOURCE_URL: jdbc:postgresql://pam_postgres:5432/pam_database
-  #     SPRING_DATASOURCE_USERNAME: spring
-  #     SPRING_DATASOURCE_PASSWORD: spring
-  #   depends_on:
-  #     - postgres
-  #   networks:
-  #     - pam_network
+  spring-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: pam_spring_app
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://pam_postgres:5432/pam_database
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    depends_on:
+      - postgres
+    networks:
+      - pam_network
 
 volumes:
   postgres_data:
 
-# networks:
-#   pam_network:
+networks:
+  pam_network:

--- a/pom.xml
+++ b/pom.xml
@@ -90,4 +90,13 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>skip-flyway</id>
+			<properties>
+				<spring.flyway.enabled>false</spring.flyway.enabled>
+			</properties>
+		</profile>
+	</profiles>
+
 </project>


### PR DESCRIPTION
- uncommented spring-app and network related portions of docker-compose.yml file so that pam services are started up again during start-service-and-database script execution

- added skip-flyway profile to pom.xml file to provide option not to run Flyway scripts during ./mvnw clean install execution

- modified start-service-and-database.sh script such that skip-flyway profile is used during ./mvnw clean install execution since pam_database is not running and would result in an error. Flyway scripts are instead executed on service startup in a Docker container, which is after database initialization