### PR TITLE
Move log in and JWT generation logic to service layer and evaluate against user email and hashed password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/emsquare/roomie_find/pam/configurations/JwtConfiguration.java
+++ b/src/main/java/emsquare/roomie_find/pam/configurations/JwtConfiguration.java
@@ -1,0 +1,17 @@
+package emsquare.roomie_find.pam.configurations;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class JwtConfiguration {
+    @Value("${jwt.secret.key}")
+    private String jwtSecretKey;
+
+    @PostConstruct
+    public void setJwtSecretKey() {
+        System.setProperty("JWT_SECRET_KEY", jwtSecretKey);
+    }
+}

--- a/src/main/java/emsquare/roomie_find/pam/controllers/AccessController.java
+++ b/src/main/java/emsquare/roomie_find/pam/controllers/AccessController.java
@@ -1,9 +1,5 @@
 package emsquare.roomie_find.pam.controllers;
 
-import java.security.Key;
-import java.util.Base64;
-import java.util.Date;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,41 +11,28 @@ import emsquare.roomie_find.pam.dtos.LoginRequest;
 import emsquare.roomie_find.pam.dtos.LoginResponse;
 import emsquare.roomie_find.pam.dtos.UserDto;
 import emsquare.roomie_find.pam.services.UserService;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 
 @RestController
 @RequestMapping("/pam")
 @CrossOrigin(origins = "*")
 public class AccessController {
     
-    // TODO: Move non-controller logic to business layer.
-    
-    // TODO: Replace with secret key.
-    private static final String SECRET_KEY_STRING = "someBase64StringThatMeetsTheStandardOfBeingAtLeast";
-    private static final Key SECRET_KEY = Keys.hmacShaKeyFor(Base64.getDecoder().decode(SECRET_KEY_STRING));
     private final UserService userService;
 
     public AccessController(UserService userService) {
         this.userService = userService;
     }
 
-    @PostMapping("/login")
-    public LoginResponse login(@RequestBody LoginRequest loginRequest) {
-        // TODO: Replace this with legitimate authentication logic.
+    // @PostMapping("/login")
+    // public LoginResponse login(@RequestBody LoginRequest loginRequest) {
+    //     return userService.attemptLogin(loginRequest);
+    // }
 
-        if ("admin".equals(loginRequest.getEmail()) && "password".equals(loginRequest.getPassword())) {
-            String token = Jwts.builder()
-                .claim("sub", loginRequest.getEmail())
-                .claim("iat", new Date())
-                .claim("exp", new Date(System.currentTimeMillis() + 3600000))
-                .signWith(SECRET_KEY)
-                .compact();
-            return new LoginResponse(token);
-        } else {
-            throw new RuntimeException("Invalid credentials");
-        }
-    }
+    @PostMapping("/login")
+public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+    LoginResponse response = userService.attemptLogin(loginRequest);
+    return ResponseEntity.ok(response);
+}
 
     @PostMapping("/register")
     public ResponseEntity<UserDto> registerUser(@RequestBody UserDto userDto) {

--- a/src/main/java/emsquare/roomie_find/pam/exceptions/EmailNotFoundException.java
+++ b/src/main/java/emsquare/roomie_find/pam/exceptions/EmailNotFoundException.java
@@ -1,0 +1,7 @@
+package emsquare.roomie_find.pam.exceptions;
+
+public class EmailNotFoundException extends RuntimeException {
+    public EmailNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/emsquare/roomie_find/pam/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/emsquare/roomie_find/pam/exceptions/GlobalExceptionHandler.java
@@ -15,5 +15,16 @@ public class GlobalExceptionHandler {
         ApiError apiError = new ApiError(HttpStatus.CONFLICT, ex.getMessage());
         return new ResponseEntity<ApiError>(apiError, HttpStatus.CONFLICT);
     }
-    
+
+    @ExceptionHandler(PasswordIncorrectException.class)
+    public ResponseEntity<ApiError> handlePasswordIncorrectException(PasswordIncorrectException ex) {
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, ex.getMessage());
+        return new ResponseEntity<ApiError>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EmailNotFoundException.class)
+    public ResponseEntity<ApiError> handleEmailNotFoundException(EmailNotFoundException ex) {
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND, ex.getMessage());
+        return new ResponseEntity<ApiError>(apiError, HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/main/java/emsquare/roomie_find/pam/exceptions/PasswordIncorrectException.java
+++ b/src/main/java/emsquare/roomie_find/pam/exceptions/PasswordIncorrectException.java
@@ -1,0 +1,7 @@
+package emsquare.roomie_find.pam.exceptions;
+
+public class PasswordIncorrectException extends RuntimeException {
+    public PasswordIncorrectException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/emsquare/roomie_find/pam/services/UserService.java
+++ b/src/main/java/emsquare/roomie_find/pam/services/UserService.java
@@ -2,10 +2,13 @@ package emsquare.roomie_find.pam.services;
 
 import java.util.Optional;
 
+import emsquare.roomie_find.pam.dtos.LoginRequest;
+import emsquare.roomie_find.pam.dtos.LoginResponse;
 import emsquare.roomie_find.pam.dtos.UserDto;
 import emsquare.roomie_find.pam.entities.User;
 
 public interface UserService {
     UserDto registerUser(UserDto userDto);
     Optional<User> findUserByEmail(String email);
+    LoginResponse attemptLogin(LoginRequest loginRequest);
 }

--- a/src/main/java/emsquare/roomie_find/pam/services/UserServiceImpl.java
+++ b/src/main/java/emsquare/roomie_find/pam/services/UserServiceImpl.java
@@ -1,13 +1,23 @@
 package emsquare.roomie_find.pam.services;
 
+import emsquare.roomie_find.pam.dtos.LoginRequest;
+import emsquare.roomie_find.pam.dtos.LoginResponse;
 import emsquare.roomie_find.pam.dtos.UserDto;
 import emsquare.roomie_find.pam.entities.User;
+import emsquare.roomie_find.pam.exceptions.EmailNotFoundException;
 import emsquare.roomie_find.pam.exceptions.EmailUsedException;
+import emsquare.roomie_find.pam.exceptions.PasswordIncorrectException;
 import emsquare.roomie_find.pam.mappers.UserMapper;
 import emsquare.roomie_find.pam.repositories.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+
+import org.mindrot.jbcrypt.BCrypt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.Optional;
 
 @Service
@@ -36,5 +46,32 @@ public class UserServiceImpl implements UserService {
     @Override
     public Optional<User> findUserByEmail(String email) {
         return userRepository.findByEmail(email);
+    }
+
+    @Override
+    public LoginResponse attemptLogin(LoginRequest loginRequest) throws PasswordIncorrectException, EmailNotFoundException {
+        Optional<User> userOptional = findUserByEmail(loginRequest.getEmail());
+        if (userOptional.isPresent()) {
+            User user = userOptional.get();
+            if (BCrypt.checkpw(loginRequest.getPassword(), user.getPasswordHash())) {
+                String secretKey = System.getProperty("JWT_SECRET_KEY");
+                if (secretKey == null || secretKey.isEmpty()) {
+                    throw new RuntimeException("JWT secret key is not configured.");
+                }
+                Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+                String token = Jwts.builder()
+                        .setSubject(user.getEmail())
+                        .setIssuedAt(new Date())
+                        .setExpiration(new Date(System.currentTimeMillis() + 3600000))
+                        .signWith(key)
+                        .compact();
+
+                return new LoginResponse(token);
+            } else {
+                throw new PasswordIncorrectException("Password is incorrect for user: " + loginRequest.getEmail());
+            }
+        }
+        throw new EmailNotFoundException("Email address " + loginRequest.getEmail() + " not found.");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,3 +43,7 @@ logging.level.org.flywaydb=DEBUG
 # Specifies the database driver class name. This is necessary when Flyway cannot determine the driver class name from the URL. Generally not needed in a Spring Boot application, as Spring Boot auto-detects the driver based on the database URL. Included here for completeness.
 flyway.driver=org.postgresql.Driver
 # &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+
+
+# JWT Configuration
+jwt.secret.key=mocked-secret-key-with-more-chars-to-meet-the-length-requirement

--- a/src/test/java/emsquare/roomie_find/pam/controllers/AccessControllerIntegrationTest.java
+++ b/src/test/java/emsquare/roomie_find/pam/controllers/AccessControllerIntegrationTest.java
@@ -17,11 +17,14 @@ import org.springframework.http.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import emsquare.roomie_find.pam.dtos.LoginRequest;
 import emsquare.roomie_find.pam.dtos.UserDto;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test") // Searches for the application-test.properties file for configuration. If this were not specified, it would use the default application.properties file. The text between the "application-" and ".properties" is the name of the profile. 
+@ActiveProfiles("test") // Searches for the application-test.properties file for configuration. If this
+                        // were not specified, it would use the default application.properties file. The
+                        // text between the "application-" and ".properties" is the name of the profile.
 public class AccessControllerIntegrationTest {
 
     @Autowired
@@ -33,9 +36,9 @@ public class AccessControllerIntegrationTest {
     @Test
     public void testRegisterUser() throws Exception {
         UserDto userDto = new UserDto();
-        userDto.setFirstName("John");
+        userDto.setFirstName("Johnnie");
         userDto.setLastName("Doe");
-        userDto.setEmail("john.doe@example.com");
+        userDto.setEmail("johnnie.doe@example.com");
         userDto.setPassword("password");
         userDto.setBirthDate(LocalDate.now());
 
@@ -43,9 +46,9 @@ public class AccessControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userDto)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.firstName").value("John"))
+                .andExpect(jsonPath("$.firstName").value("Johnnie"))
                 .andExpect(jsonPath("$.lastName").value("Doe"))
-                .andExpect(jsonPath("$.email").value("john.doe@example.com"));
+                .andExpect(jsonPath("$.email").value("johnnie.doe@example.com"));
     }
 
     @Test
@@ -68,5 +71,68 @@ public class AccessControllerIntegrationTest {
                 .content(objectMapper.writeValueAsString(userDto)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("Email address used.email@example.com is already in use."));
+    }
+
+    @Test
+    public void testLoginSuccess() throws Exception {
+        UserDto userDto = new UserDto();
+        userDto.setFirstName("John");
+        userDto.setLastName("Doe");
+        userDto.setEmail("john.doe@example.com");
+        userDto.setPassword("password");
+        userDto.setBirthDate(LocalDate.now());
+
+        mockMvc.perform(post("/pam/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userDto)))
+                .andExpect(status().isOk());
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("john.doe@example.com");
+        loginRequest.setPassword("password");
+
+        mockMvc.perform(post("/pam/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").exists());
+    }
+
+    @Test
+    public void testLoginFailureIncorrectPassword() throws Exception {
+        UserDto userDto = new UserDto();
+        userDto.setFirstName("Blake");
+        userDto.setLastName("Bob");
+        userDto.setEmail("blake.bob@example.com");
+        userDto.setPassword("password");
+        userDto.setBirthDate(LocalDate.now());
+
+        mockMvc.perform(post("/pam/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userDto)))
+                .andExpect(status().isOk());
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("blake.bob@example.com");
+        loginRequest.setPassword("wrongpassword");
+
+        mockMvc.perform(post("/pam/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Password is incorrect for user: blake.bob@example.com"));
+    }
+
+    @Test
+    public void testLoginFailureEmailNotFound() throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("nonexistent.email@example.com");
+        loginRequest.setPassword("password");
+
+        mockMvc.perform(post("/pam/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Email address nonexistent.email@example.com not found."));
     }
 }

--- a/src/test/java/emsquare/roomie_find/pam/controllers/AccessControllerTest.java
+++ b/src/test/java/emsquare/roomie_find/pam/controllers/AccessControllerTest.java
@@ -3,8 +3,6 @@ package emsquare.roomie_find.pam.controllers;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -17,9 +15,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import emsquare.roomie_find.pam.dtos.LoginRequest;
+import emsquare.roomie_find.pam.dtos.LoginResponse;
 import emsquare.roomie_find.pam.dtos.UserDto;
+import emsquare.roomie_find.pam.exceptions.PasswordIncorrectException;
 import emsquare.roomie_find.pam.services.UserService;
-import jakarta.servlet.ServletException;
 
 @WebMvcTest(AccessController.class)
 public class AccessControllerTest {
@@ -36,28 +35,33 @@ public class AccessControllerTest {
     @Test
     public void testLoginSuccess() throws Exception {
         LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail("admin");
+        loginRequest.setEmail("admin@example.com");
         loginRequest.setPassword("password");
+
+        LoginResponse loginResponse = new LoginResponse("mocked-jwt-token");
+
+        Mockito.when(userService.attemptLogin(Mockito.any(LoginRequest.class))).thenReturn(loginResponse);
 
         mockMvc.perform(post("/pam/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.token", notNullValue()));
+                .andExpect(jsonPath("$.token").value("mocked-jwt-token"));
     }
 
     @Test
-    public void testLoginFailure() throws Exception {
+    public void testLoginFailurePasswordIncorrect() throws Exception {
         LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail("admin");
+        loginRequest.setEmail("admin@example.com");
         loginRequest.setPassword("wrongpassword");
 
-        assertThrows(ServletException.class, () -> {
-            mockMvc.perform(post("/pam/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(loginRequest)))
-                    .andExpect(status().isOk());
-        });
+        Mockito.when(userService.attemptLogin(Mockito.any(LoginRequest.class)))
+                .thenThrow(new PasswordIncorrectException("Password is incorrect for user: admin@example.com"));
+
+        mockMvc.perform(post("/pam/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/emsquare/roomie_find/pam/services/UserServiceImplTest.java
+++ b/src/test/java/emsquare/roomie_find/pam/services/UserServiceImplTest.java
@@ -1,13 +1,18 @@
 package emsquare.roomie_find.pam.services;
 
+import emsquare.roomie_find.pam.dtos.LoginRequest;
+import emsquare.roomie_find.pam.dtos.LoginResponse;
 import emsquare.roomie_find.pam.dtos.UserDto;
 import emsquare.roomie_find.pam.entities.User;
+import emsquare.roomie_find.pam.exceptions.EmailNotFoundException;
 import emsquare.roomie_find.pam.exceptions.EmailUsedException;
+import emsquare.roomie_find.pam.exceptions.PasswordIncorrectException;
 import emsquare.roomie_find.pam.mappers.UserMapper;
 import emsquare.roomie_find.pam.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
@@ -42,6 +47,8 @@ public class UserServiceImplTest {
         userDto.setEmail(EMAIL);
         userDto.setPassword(PASSWORD);
         userDto.setBirthDate(BIRTH_DATE);
+
+        System.setProperty("JWT_SECRET_KEY", "mocked-secret-key-with-more-chars-to-meet-the-length-requirement");
     }
 
     @Test
@@ -84,5 +91,60 @@ public class UserServiceImplTest {
 
         verify(userRepository, times(1)).findByEmail(EMAIL);
         verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    public void testAttemptLoginSuccess() {
+        User user = UserMapper.toEntity(userDto);
+
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail(EMAIL);
+        loginRequest.setPassword(PASSWORD);
+
+        LoginResponse loginResponse = userService.attemptLogin(loginRequest);
+
+        assertNotNull(loginResponse);
+        assertNotNull(loginResponse.getToken());
+
+        verify(userRepository, times(1)).findByEmail(EMAIL);
+    }
+
+    @Test
+    public void testAttemptLoginEmailNotFound() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail(EMAIL);
+        loginRequest.setPassword(PASSWORD);
+
+        EmailNotFoundException exception = assertThrows(EmailNotFoundException.class, () -> {
+            userService.attemptLogin(loginRequest);
+        });
+
+        assertEquals("Email address " + EMAIL + " not found.", exception.getMessage());
+
+        verify(userRepository, times(1)).findByEmail(EMAIL);
+    }
+
+    @Test
+    public void testAttemptLoginIncorrectPassword() {
+        User user = UserMapper.toEntity(userDto);
+        user.setPasswordHash(BCrypt.hashpw("differentpassword", BCrypt.gensalt()));
+
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail(EMAIL);
+        loginRequest.setPassword(PASSWORD);
+
+        PasswordIncorrectException exception = assertThrows(PasswordIncorrectException.class, () -> {
+            userService.attemptLogin(loginRequest);
+        });
+
+        assertEquals("Password is incorrect for user: " + EMAIL, exception.getMessage());
+
+        verify(userRepository, times(1)).findByEmail(EMAIL);
     }
 }


### PR DESCRIPTION
- Added jwt.secret.key to application.properties file.
- Added JwtConfiguration class.
- Modified JWT_SECRET_KEY to be set as a system property after application construction.
- Added javax.annotation-api depedency to pom.xml file to access PostConstruct annotation for to set JWT_SECRET_KEY.
- Moved JWT generation logic from AccessController to UserServiceImpl.
- Added attemptLogin method to UserService.java interface.
- Added attemptLogin method to UserServiceImpl.java class.
- Added EmailNotFoundException and added it to GlobalExceptionHandler.
- Added PasswordIncorectException and added it to GlobalExceptionHandler.
- Modified AccessControllerTest file tests.
- Added tests for new logic to UserServiceImplTest file.
- Added test for new logic to AccessControllerIntegrationTest.java file.